### PR TITLE
feat: use @Resource decorator without @Scopes decorator on method

### DIFF
--- a/src/guards/resource.guard.ts
+++ b/src/guards/resource.guard.ts
@@ -92,7 +92,9 @@ export class ResourceGuard implements CanActivate {
     );
 
     // Build permissions
-    const permissions = scopes.map(scope => `${resource}:${scope}`);
+    const permissions = scopes?.map(scope => `${resource}:${scope}`) ?? [
+      resource,
+    ];
     // Extract request/response
     const [request, response] = extractRequest(context);
 


### PR DESCRIPTION
allow resource based access control without needing to define a @Scopes decorator